### PR TITLE
fix precedence in multiproof.py

### DIFF
--- a/multiproof/multiproof.py
+++ b/multiproof/multiproof.py
@@ -154,7 +154,7 @@ class MultiProof:
             z = query.z.value
             y = query.y
             # TODO: clean this up, its not very readable
-            E_coefficient = power_of_r / t - self.precomp.domain[z]
+            E_coefficient = power_of_r / (t - self.precomp.domain[z])
             C_serialized = bytes(C.to_bytes())
             C_by_serialized[C_serialized] = C
             E_coefficients[C_serialized] = E_coefficient if C_serialized not in E_coefficients \


### PR DESCRIPTION
The current precedence seems wrong and the fact that the test passes is probably an artifact of using only a domain of size 2.